### PR TITLE
Use https URL rather than Git url

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "jquery": "latest",
     "loophole": "latest",
-    "tern": "git://github.com/marijnh/tern.git",
+    "tern": "https://github.com/marijnh/tern.git",
     "atom-package-dependencies": "latest"
   },
   "package-dependencies": {


### PR DESCRIPTION
Git url uses ssh which might be troublesome behind proxies. Using http facilities the use of an http proxy (which very likely already is set in these environment).