### PR TITLE
Wrong prefix when typing a dot after an object

### DIFF
--- a/lib/atom-ternjs-provider.coffee
+++ b/lib/atom-ternjs-provider.coffee
@@ -38,6 +38,8 @@ class Provider
             return ''
         if (!prefix.replace(/\s/g, '').length) or prefix.endsWith(';')
             return ''
+        if prefix.lastIndexOf('.') is prefix.length - 1
+            return ''
         prefix
 
     requestHandler: (options) ->


### PR DESCRIPTION
```javascript
var test = {
    prop1: function() { return null; },
    prop2: function() { return null; }
};
```

When I type 'test.' then the prefix will be a dot and after selecting a property from the dropdown the result will be: 'testprop1'. Also with JQuery objects the prefix will be '). . This pull request fixes this issue.