### PR TITLE
Fix atom freezes while fast cursor move

### DIFF
--- a/lib/atom-ternjs-view-manager.coffee
+++ b/lib/atom-ternjs-view-manager.coffee
@@ -25,7 +25,8 @@ class ViewManager
         @renamePanel = atom.workspace.addBottomPanel item: @renameModel
 
     hideRename: ->
-        @renamePanel?.hide()
+        return unless @renamePanel?.isVisible()
+        @renamePanel.hide()
         @focusEditor()
 
     focusEditor: ->

--- a/lib/atom-ternjs-view-manager.coffee
+++ b/lib/atom-ternjs-view-manager.coffee
@@ -4,33 +4,33 @@ RenameView = require './atom-ternjs-rename-view'
 module.exports =
 class ViewManager
 
-    renamePanel: null
-    renameModel: null
-    manager: null
+  renamePanel: null
+  renameModel: null
+  manager: null
 
-    constructor: (manager) ->
-        @manager = manager
-        @registerViewProvider()
+  constructor: (manager) ->
+    @manager = manager
+    @registerViewProvider()
 
-    registerViewProvider: ->
-        atom.views.addViewProvider
-            modelConstructor: RenameModel
-            viewConstructor: RenameView
+  registerViewProvider: ->
+    atom.views.addViewProvider
+      modelConstructor: RenameModel
+      viewConstructor: RenameView
 
-    showRename: ->
-        if @renamePanel
-            @renamePanel.show()
-            return
-        @renameModel = new RenameModel(@manager)
-        @renamePanel = atom.workspace.addBottomPanel item: @renameModel
+  showRename: ->
+    if @renamePanel
+      @renamePanel.show()
+      return
+    @renameModel = new RenameModel(@manager)
+    @renamePanel = atom.workspace.addBottomPanel item: @renameModel
 
-    hideRename: ->
-        return unless @renamePanel?.isVisible()
-        @renamePanel.hide()
-        @focusEditor()
+  hideRename: ->
+    return unless @renamePanel?.isVisible()
+    @renamePanel.hide()
+    @focusEditor()
 
-    focusEditor: ->
-        editor = atom.workspace.getActiveTextEditor()
-        return unless editor
-        view = atom.views.getView(editor)
-        view?.focus?()
+  focusEditor: ->
+    editor = atom.workspace.getActiveTextEditor()
+    return unless editor
+    view = atom.views.getView(editor)
+    view?.focus?()


### PR DESCRIPTION
Fixes #51

Check `Panel#isVisible` before focus() call which significantly affects
Atom's performance.