### PR TITLE
Rename panel improvements

### DIFF
--- a/lib/atom-ternjs-rename-view.coffee
+++ b/lib/atom-ternjs-rename-view.coffee
@@ -22,23 +22,20 @@ class RenameView extends HTMLElement
       @model.hide()
       return
 
-    editor = document.createElement('atom-text-editor')
-    editor.setAttribute('mini', true)
+    @nameEditor = document.createElement('atom-text-editor')
+    @nameEditor.setAttribute('mini', true)
+    @nameEditor.addEventListener 'core:confirm', (e) => @rename()
 
     buttonRename = document.createElement('button')
     buttonRename.innerHTML = 'Rename'
     buttonRename.id = 'close'
     buttonRename.classList.add('btn')
     buttonRename.classList.add('mt')
-    buttonRename.addEventListener 'click', (e) =>
-      editor = @querySelector('atom-text-editor')
-      text = editor.getModel().getBuffer().getText()
-      return unless text
-      @model.updateAllAndRename(text)
+    buttonRename.addEventListener 'click', (e) => @rename()
 
     wrapper.appendChild(title)
     wrapper.appendChild(sub)
-    wrapper.appendChild(editor)
+    wrapper.appendChild(@nameEditor)
     wrapper.appendChild(buttonClose)
     wrapper.appendChild(buttonRename)
     container.appendChild(wrapper)
@@ -54,6 +51,11 @@ class RenameView extends HTMLElement
 
   setModel: (model) ->
     @model = model
+
+  rename: ->
+    text = @nameEditor.getModel().getBuffer().getText()
+    return unless text
+    @model.updateAllAndRename(text)
 
   destroy: ->
     @remove()

--- a/lib/atom-ternjs-rename.coffee
+++ b/lib/atom-ternjs-rename.coffee
@@ -25,7 +25,18 @@ class Rename
     @manager.helper.focusEditor()
 
   show: ->
+    codeEditor = atom.workspace.getActiveTextEditor()
+
+    currentNameRange = codeEditor.getLastCursor().getCurrentWordBufferRange
+      includeNonWordCharacters: false
+
+    currentName = codeEditor.getTextInBufferRange(currentNameRange)
+
+    @renameView.nameEditor.getModel().setText(currentName)
+    @renameView.nameEditor.getModel().selectAll()
+
     @renamePanel.show()
+    @renameView.nameEditor.focus()
 
   updateAllAndRename: (newName) ->
     return unless @manager.client


### PR DESCRIPTION
I've made a few improvements to the rename panel:

* When the panel is shown, the word under the cursor in the active code editor is set as the contents of the new name field. Useful if the user only wants to make small changes to the existing name.

* The name field is focused so you don't need to use the mouse.

* The name in the field is automatically fully selected so it can also be easily replaced with something new.

* Instead of clicking on the Rename button, you can also press enter on the name field.