### PR TITLE
Use short GitHub URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "jquery": "*",
     "loophole": "*",
-    "tern": "git+https://github.com/marijnh/tern.git",
-    "tern-lint": "git+https://github.com/angelozerr/tern-lint.git",
+    "tern": "marijnh/tern",
+    "tern-lint": "angelozerr/tern-lint",
     "underscore-plus": "*"
   },
   "providedServices": {


### PR DESCRIPTION
Fixes #114 and "Unable to find remote helper for 'https'" errors.
(Git must still be in PATH, however.)

According to the [npm docs][1], npm v1.1.65 and later supports short GitHub URLs.
atom-ternjs [supports Atom v1.0.0 and later][2].
Atom v1.0.0 [comes with apm v1.0.1][3].
apm v1.0.1 [comes with npm v2.5.1][4].
Therefore, atom-ternjs can use short GitHub URLs.

[1]: https://docs.npmjs.com/files/package.json#github-urls
[2]: https://github.com/tststs/atom-ternjs/blob/v0.8.2/package.json#L11
[3]: https://github.com/atom/atom/blob/v1.0.0/apm/package.json#L9
[4]: https://github.com/atom/apm/blob/v1.0.1/package.json#L33