### PR TITLE
Check whether project path is a directory

### DIFF
--- a/lib/atom-ternjs-manager.coffee
+++ b/lib/atom-ternjs-manager.coffee
@@ -1,3 +1,4 @@
+fs = require 'fs'
 Helper = require './atom-ternjs-helper'
 Config = require './atom-ternjs-config'
 Server = null
@@ -77,7 +78,7 @@ class Manager
     return unless dirs.length
     for i in [0..dirs.length - 1]
       dir = atom.project.relativizePath(dirs[i].path)[0]
-      @startServer(dir)
+      @startServer(dir) if @isDirectory dir
 
   startServer: (dir) ->
     Server = require './atom-ternjs-server' if !Server
@@ -118,7 +119,10 @@ class Manager
   checkPaths: (paths) ->
     for path in paths
       dir = atom.project.relativizePath(path)[0]
-      @startServer(dir)
+      @startServer(dir) if @isDirectory dir
+
+  isDirectory: (dir) ->
+    fs.statSync(dir).isDirectory()
 
   destroyServer: (paths) ->
     return unless @servers.length


### PR DESCRIPTION
When Atom is opened with a file as its path, or when right-click > Open with Atom is used on a file, atom-ternjs fails with the error:

> BufferedProcessError: Failed to spawn command `...\node_modules\.bin\tern`. Make sure `...\node_modules\.bin\tern` is installed and on your PATH.

This appears to be specific to Windows installations. This PR fixes that issue.

The error is misleading because you don't actually need Tern to be in your PATH, nor does that solve the issue. The error appears because the `cwd` option is is a reference to a file, instead of a directory, when BufferedProcess is called.

This fix stops the process early when the project does not contain any paths, which is in agreement with the message given when you attempt to open the Tern Config in the same situation:

> There is no active project. Please re-open or focus at least one JavaScript file of the project to configure.

Fixes #90