### PR TITLE
Use specific versions in package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "jquery": "^2.1.4",
     "loophole": "^1.1.0",
-    "tern": "^0.15.0",
+    "tern": "marijnh/tern",
     "tern-lint": "^0.5.0",
     "underscore-plus": "^1.6.6"
   },

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "atom": ">=1.0.0"
   },
   "dependencies": {
-    "jquery": "*",
-    "loophole": "*",
-    "tern": "git+https://github.com/marijnh/tern.git",
-    "tern-lint": "git+https://github.com/angelozerr/tern-lint.git",
-    "underscore-plus": "*"
+    "jquery": "^2.1.4",
+    "loophole": "^1.1.0",
+    "tern": "^0.15.0",
+    "tern-lint": "^0.5.0",
+    "underscore-plus": "^1.6.6"
   },
   "providedServices": {
     "autocomplete.provider": {


### PR DESCRIPTION
Versions in dependencies should be specified rather than using wildcards or URLs. If a dependency is updated to a new version with breaking changes, this package might break as well. Pinning specific versions or version ranges can almost ensure that breaking changes are not introduced.

This update uses [Caret Ranges][1] so that minor and patch versions are updated, but major versions are not.

[1]: https://github.com/npm/node-semver/blob/v5.0.3/README.md#caret-ranges-123-025-004

Fixes #114
Fixes #116
Fixes #137 
Closes #141