### PR TITLE
Escape right curly braces in snippets

### DIFF
--- a/lib/atom-ternjs-helper.coffee
+++ b/lib/atom-ternjs-helper.coffee
@@ -128,6 +128,7 @@ class Helper
     return "#{name}()" if params.length is 0
     suggestionParams = []
     for param, i in params
+      param = param.replace '}', '\\}'
       suggestionParams.push "${#{i + 1}:#{param}}"
     "#{name}(#{suggestionParams.join(',')})"
 


### PR DESCRIPTION
To work properly, right curly braces (`}`) should be escaped in snippets.

See atom/snippets#163

Fixes #118