### PR TITLE
Catch `fs.statSync` errors

### DIFF
--- a/lib/atom-ternjs-helper.coffee
+++ b/lib/atom-ternjs-helper.coffee
@@ -22,7 +22,8 @@ class Helper
     catch e then return false
 
   isDirectory: (dir) ->
-    fs.statSync(dir).isDirectory()
+    try return fs.statSync(dir).isDirectory()
+    catch then return false
 
   writeFile: (filePath, content) ->
     fs.writeFile filePath, content, (err) =>


### PR DESCRIPTION
If a non-string value or invalid path is passed to `fs.statSync()`, an error will be thrown. Catch that error and return `false` when checking whether a path is a directory.

Fixes #147
Fixes #148