### PR TITLE
Added option to display suggestions above snippets

### DIFF
--- a/lib/atom-ternjs-package-config.js
+++ b/lib/atom-ternjs-package-config.js
@@ -12,6 +12,7 @@ export default class PackageConfig {
       excludeLowerPriority: atom.config.get('atom-ternjs.excludeLowerPriorityProviders'),
       inlineFnCompletion: atom.config.get('atom-ternjs.inlineFnCompletion'),
       useSnippets: atom.config.get('atom-ternjs.useSnippets'),
+      displayAboveSnippets: atom.config.get('atom-ternjs.displayAboveSnippets'),
       useSnippetsAndFunction: atom.config.get('atom-ternjs.useSnippetsAndFunction'),
       doNotAddParantheses: atom.config.get('atom-ternjs.doNotAddParantheses'),
       sort: atom.config.get('atom-ternjs.sort'),

--- a/lib/atom-ternjs-provider.coffee
+++ b/lib/atom-ternjs-provider.coffee
@@ -15,6 +15,8 @@ class Provider
   init: (manager) ->
     @manager = manager
     @excludeLowerPriority = @manager.packageConfig.options.excludeLowerPriorityProviders
+    if @manager.packageConfig.options.displayAboveSnippets
+      @suggestionPriority = 2
 
   isValidPrefix: (prefix) ->
     return true if prefix[prefix.length - 1] is '\.'

--- a/lib/atom-ternjs.coffee
+++ b/lib/atom-ternjs.coffee
@@ -40,48 +40,54 @@ module.exports =
       type: 'boolean'
       default: true
       order: 4
+    displayAboveSnippets:
+      title: 'Display above snippets'
+      description: 'Displays ternjs suggestions above snippet suggestions. Requires a restart.'
+      type: 'boolean'
+      default: false
+      order: 5
     useSnippetsAndFunction:
       title: 'Display both, autocomplete-snippets and function name'
       description: 'Choose to just complete the function name or expand the snippet'
       type: 'boolean'
       default: false
-      order: 5
+      order: 6
     doNotAddParantheses:
       title: 'Do not add parantheses if method is completed'
       description: 'Currently only works if "Use autocomplete-snippets" and "Display both, autocomplete-snippets and function name" are both disabled.'
       type: 'boolean'
       default: false
-      order: 6
+      order: 7
     inlineFnCompletion:
       title: 'Display inline suggestions for function params'
       description: 'Displays a inline suggestion located right next to the current cursor'
       type: 'boolean'
       default: true
-      order: 7
+      order: 8
     lint:
       title: 'Use tern-lint'
       description: 'Use tern-lint to validate JavaScript files to collect semantic errors. Restart atom after this option has been changed.'
       type: 'boolean'
       default: true
-      order: 8
+      order: 9
     documentation:
       title: 'Documentation'
       description: 'Whether to include documentation string (if found) in the result data.'
       type: 'boolean'
       default: true
-      order: 9
+      order: 10
     urls:
       title: 'Url'
       description: 'Whether to include documentation urls (if found) in the result data.'
       type: 'boolean'
       default: true
-      order: 10
+      order: 11
     origins:
       title: 'Origin'
       description: 'Whether to include origins (if found) in the result data.'
       type: 'boolean'
       default: true
-      order: 11
+      order: 12
 
   activate: (state) ->
     @provider = new Provider()


### PR DESCRIPTION
This adds an option to display ternjs suggestions above snippets, instead of displaying them below them.

These two pictures illustrate the change:
Before: ![before](http://i.imgur.com/7DA3uFj.png)
After: ![after](http://i.imgur.com/sFpYN5b.png)

This is an option (visible in the preferences), which defaults to false, meaning the default behavior isn't changed.