### PR TITLE
3-rd party tern modules got incorrect tern directory

### DIFF
--- a/lib/atom-ternjs-server-worker.js
+++ b/lib/atom-ternjs-server-worker.js
@@ -4,7 +4,7 @@ var path = require('path');
 var minimatch = require('minimatch');
 var fs = require('fs');
 
-var TERN_ROOT = '../node_modules/tern';
+var TERN_ROOT = path.resolve(__dirname,'../node_modules/tern');
 var TernServer;
 
 module.exports = TernServer = function () {


### PR DESCRIPTION
When Atom invoked from project directory by command line, and if there is any additional tern modules when they invoked with "../node_modules/tern" relative to current project