### PR TITLE
fixed (very) minor typo in config view

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -69,7 +69,7 @@ export default {
   inlineFnCompletionDocumentation: {
 
     title: 'Display inline suggestions with additional documentation (if any)',
-    description: 'Adds documentation to the inline functionm completion',
+    description: 'Adds documentation to the inline function completion',
     type: 'boolean',
     default: false,
     order: 8


### PR DESCRIPTION
Removed extra 'm' character in "Display inline suggestions with additional documentation (if any)" option's description.

"Adds documentation to the inline function**m** completion" became -> "Adds documentation to the inline function completion"