### PR TITLE
Delay activation until needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.15.0",
   "private": false,
   "description": "JavaScript code intelligence for atom with Tern. Adds support for ES5, ES6 (JavaScript 2015), Node.js, jQuery & Angular. Extendable via plugins. Uses suggestion provider by autocomplete-plus.",
-  "activationCommands": {},
+  "activationHooks": [ "language-javascript:grammar-used" ],
   "repository": "https://github.com/tststs/atom-ternjs",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Before this change, atom-ternjs was activated on Atom startup, whether
or not you actually had any .js files open.

With this change in place, we postpone activating atom-ternjs until the
Atom JavaScript grammar's first use.

This improves startup time of my Atom by 100ms-200ms, and was the
current top startup time offender according to TimeCop.

For some frame of reference, I have 124 packages installed, and the
second biggest offender is at 47ms.