### PR TITLE
Fix jumping to definition in multi-project workspace

### DIFF
--- a/lib/atom-ternjs-client.js
+++ b/lib/atom-ternjs-client.js
@@ -198,7 +198,7 @@ export default class Client {
     const editor = atom.workspace.getActiveTextEditor();
     const cursor = editor.getLastCursor();
     const position = cursor.getBufferPosition();
-    const file = atom.project.relativizePath(editor.getURI())[1];
+    const [project, file] = atom.project.relativizePath(editor.getURI());
     const end = {
 
       line: position.row,
@@ -219,7 +219,7 @@ export default class Client {
       if (data && data.start) {
 
         setMarkerCheckpoint();
-        openFileAndGoTo(data.start, data.file);
+        openFileAndGoTo(data.start, `${project}/${data.file}`);
       }
     }).catch((err) => {
 


### PR DESCRIPTION
Fixes #272 but possibly not the more general case of "reference to a file path in a multi-project workspace".