### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/spec/atom-ternjs-spec.js
+++ b/spec/atom-ternjs-spec.js
@@ -1,6 +1,6 @@
 'use babel'
 
-let [workspaceElement, editor, editorElement] = [];
+let [workspaceElement, editor, editorElement, pack] = [];
 let path = require('path');
 
 function sharedSetup() {
@@ -12,7 +12,7 @@ function sharedSetup() {
 
     return atom.packages.activatePackage('atom-ternjs').then((pkg) => {
 
-      package = pkg.mainModule;
+      pack = pkg.mainModule;
     });
   });
 
@@ -39,12 +39,12 @@ describe('atom-ternjs', () => {
 
     it('activates atom-ternjs and initializes the autocomplete-plus provider', () => {
 
-      expect(package.provider).toBeDefined();
+      expect(pack.provider).toBeDefined();
     });
 
     it('activates atom-ternjs and initializes the manager', () => {
 
-      expect(package.manager).toBeDefined();
+      expect(pack.manager).toBeDefined();
     });
   });
 
@@ -58,8 +58,8 @@ describe('atom-ternjs', () => {
 
     it('deactivates atom-ternjs', () => {
 
-      expect(package.manager).toBeUndefined();
-      expect(package.provider).toBeUndefined();
+      expect(pack.manager).toBeUndefined();
+      expect(pack.provider).toBeUndefined();
     });
 
     it('destroys all views', () => {


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!