### PR TITLE
Don't require modules in example tern-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Example `.tern-project` file (customize to your own needs):
     "path/to/your/js/**/*.js"
   ],
   "plugins": {
-    "modules": {},
     "es_modules": {},
     "node": {},
     "doc_comment": {


### PR DESCRIPTION
The `node` plugin loads the `node_resolve` plugin, which in turn loads `commonjs` plugin, which finally loads the `modules` plugin.

TLDR: if you load the `node` plugin, you already loaded the `modules` plugin.