### PR TITLE
added error logging for uncaught exceptions from workers

### DIFF
--- a/lib/atom-ternjs-server-worker.js
+++ b/lib/atom-ternjs-server-worker.js
@@ -121,7 +121,8 @@ process.on('uncaughtException', function (err) {
     error: {
 
       isUncaughtException: true,
-      message: String(err)
+      message: String(err),
+      stack: err.stack
     }
   });
 });

--- a/lib/atom-ternjs-server.js
+++ b/lib/atom-ternjs-server.js
@@ -175,6 +175,7 @@ export default class Server {
     if (e.error && e.error.isUncaughtException) {
 
       this.restart(`UncaughtException: ${e.error.message}. Restarting Server...`);
+      console.error(e.error.stack);
 
       return;
     }


### PR DESCRIPTION
i was setting up ternjs for a new project that i inherited at work, but it was having trouble parsing 
some of my webpack config for the webpack plugin because of some ESnext syntax that is unsupported by acorn. i had no idea what was actually failing, so i added some logging for the uncaught exception stacktrace from a worker. this helped me pinpoint what the unsupported configuration was so that i figure out what actually to do with the "bad" code.