### PR TITLE
remove keybindings documentation

### DIFF
--- a/keymaps/atom-ternjs.cson
+++ b/keymaps/atom-ternjs.cson
@@ -1,12 +1,3 @@
-# Keybindings require three things to be fully defined: A selector that is
-# matched against the focused element, the keystroke and the command to
-# execute.
-#
-# Below is a basic keybinding which registers on all platforms by applying to
-# the root workspace element.
-
-# For more detailed documentation see
-# https://atom.io/docs/latest/advanced/keymaps
 '.platform-darwin atom-text-editor[data-grammar~=js]':
   'ctrl-alt-shift-d': 'atom-ternjs:definition'
   'ctrl-alt-c': 'atom-ternjs:rename'


### PR DESCRIPTION
Fixes #336 

Links have been changed a few times over the past few years.
Here are the new links:

- http://flight-manual.atom.io/using-atom/sections/basic-customization/#_customizing_keybindings
- http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/

Imho, we do not need to explain how the keybindings works in the package documentation.
Chances are if you open the [Command Palette](http://flight-manual.atom.io/getting-started/sections/atom-basics/#command-palette) and type _Keymap_, you will be taken to [atom keymap file](https://github.com/atom/atom/blob/master/dot-atom/keymap.cson), which have an up to date link to the keymap documentation.