### PR TITLE
Better error log

### DIFF
--- a/lib/atom-ternjs-server-worker.js
+++ b/lib/atom-ternjs-server-worker.js
@@ -121,7 +121,8 @@ process.on('uncaughtException', function (err) {
     error: {
 
       isUncaughtException: true,
-      message: String(err)
+      message: String(err),
+      stack: String(err.stack)
     }
   });
 });

--- a/lib/atom-ternjs-server.js
+++ b/lib/atom-ternjs-server.js
@@ -159,11 +159,12 @@ export default class Server {
     });
   }
 
-  restart(message) {
+  restart(message, stack) {
 
     atom.notifications.addError(message || 'Restarting Server...', {
 
-      dismissable: false
+      dismissable: false,
+      detail: stack
     });
 
     manager.destroyServer(this.projectDir);


### PR DESCRIPTION
This will display the error stack in the notification for better debugging if the tern worker throws an uncaughtException.

before:
![image](https://user-images.githubusercontent.com/97994/62648645-d5460400-b918-11e9-8c35-b3ffa4fe5a6e.png)


After:
![image](https://user-images.githubusercontent.com/97994/62648606-c3fcf780-b918-11e9-9dc1-27e26bc5840f.png)
