### PR TITLE
Fix libs and plugins detection without local package.json

### DIFF
--- a/lib/atom-ternjs-server.js
+++ b/lib/atom-ternjs-server.js
@@ -322,9 +322,13 @@ export default class Server {
       }
 
       let found =
-        this.findFile(file, projectDir, path.resolve(this.distDir, 'defs')) ||
-        resolveFrom(projectDir, `tern-${src[i]}`)
-        ;
+        this.findFile(file, projectDir, path.resolve(this.distDir, 'defs'));
+
+      if (!found) {
+        try {
+          found = resolveFrom(projectDir, `tern-${src[i]}`);
+        } catch (e) {}
+      }
 
       if (!found) {
 
@@ -367,9 +371,14 @@ export default class Server {
       }
 
       let found =
-        this.findFile(`${plugin}.js`, projectDir, path.resolve(this.distDir, 'plugin')) ||
-        resolveFrom(projectDir, `tern-${plugin}`)
-        ;
+        this.findFile(`${plugin}.js`, projectDir, path.resolve(this.distDir, 'plugin'));
+
+      if (!found) {
+        try {
+          resolveFrom(projectDir, `tern-${plugin}`)
+        }
+        catch (e) {}
+      }
 
       if (!found) {
 


### PR DESCRIPTION
**What is expected:** If the local project folder does not have `package.json` and `node_modules`, the libs and plugins detection should skip it and go to `atom-ternjs/node_modules` package.

**What is happening:** If the local project folder does not have `package.json` and `node_modules`, it throws an error `Cannot find module tern-mylib`, despite it is present in `atom-ternjs/node_modules/tern-mylib`.

This PR fixes this using an additional try/catch block.